### PR TITLE
Fix some bugs because of the dependencies outdated

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -44,8 +44,8 @@ class JWTBearer(HTTPBearer):
     def __init__(self, auto_error: bool = True):
         super(JWTBearer, self).__init__(auto_error=auto_error)
 
-    def __call__(self, request: Request):
-        credentials: HTTPAuthorizationCredentials = super(JWTBearer, self).__call__(request)
+    async def __call__(self, request: Request):
+        credentials: HTTPAuthorizationCredentials = await super(JWTBearer, self).__call__(request)
         if credentials:
             if not credentials.scheme == "Bearer":
                 raise AuthError(detail="Invalid authentication scheme.")

--- a/app/repository/base_repository.py
+++ b/app/repository/base_repository.py
@@ -99,4 +99,5 @@ class BaseRepository:
             session.commit()
 
     def close_scoped_session(self):
-        return self.session_factory.close()
+        with self.session_factory() as session:
+            return session.close()


### PR DESCRIPTION
- The HTTPBearer.__call__ has become an asynchronous (async/await) method 
- Fix the BaseRepository.close_scoped_session method